### PR TITLE
.day instead of .hour in vaccination expiration check

### DIFF
--- a/Sources/EUDCCValidator/Models/EUDCC+ValidationRule+Defaults.swift
+++ b/Sources/EUDCCValidator/Models/EUDCC+ValidationRule+Defaults.swift
@@ -101,7 +101,7 @@ public extension EUDCC.ValidationRule {
                 lhsDate: .currentDate,
                 rhsDate: .init(
                     .keyPath(\.vaccination?.dateOfVaccination),
-                    adding: (.hour, maximumDaysSinceVaccinationDate)
+                    adding: (.day, maximumDaysSinceVaccinationDate)
                 ),
                 operator: >,
                 using: calendar,


### PR DESCRIPTION
Found a bug in isVaccinationExpired validator.